### PR TITLE
Dev/output fold results: Add option to store performance result per fold for each task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,199 @@ run_eval.sh
 run_main.sh
 **/__pycache__/
 **/*.pyc
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore

--- a/benchmark/evaluation/evaluation.py
+++ b/benchmark/evaluation/evaluation.py
@@ -90,6 +90,7 @@ def evaluate(submission_file: Path,
             output_dir=run_dir,
             filename_prefix=submission_file.stem,
             enable_plots=config.get("enable_plots", True),
+            output_fold_results=config.get("output_fold_results", False),
         )
 
         task_results[task_name] = result.q_statistic

--- a/benchmark/evaluation/linear_probing.py
+++ b/benchmark/evaluation/linear_probing.py
@@ -201,6 +201,7 @@ def cross_validate(
         filename_prefix: str,
         enable_plots: bool,
         random_seed: int = 42,
+        output_fold_results: bool = False,
         ) ->  TaskResult:
     """Perform k-fold cross-validation with a linear probe.
 
@@ -214,7 +215,10 @@ def cross_validate(
         epochs: Number of epochs to use in Linear Probe training.
         embedding_dim: Size of embeddings.
         learning_rate: Learning rate for Linear Probe training.
-        output_dir: Path to folder to 
+        output_dir: Path to folder to store results in.
+        enable_plots: Toggle storing of plots. Set to True to store plots.
+        random_seed: Integer seed for random number generator.
+        output_fold_results: Toggle storing performance metric per fold in addition to summary statistics. Default is False, in which case performance per fold is not stored.
     Returns:
         A TaskResult instance containing the evaluation results.
     """
@@ -274,6 +278,8 @@ def cross_validate(
         "mean_score": mean_score,
         "std_dev": std_dev,
     }
+    if output_fold_results:
+        result_metrics["q_t"] = best_metrics.tolist()
 
     (output_dir / task_name / f"{task_name}_result.json").write_text(
         json.dumps(result_metrics, indent=2)

--- a/benchmark/evaluation/results.py
+++ b/benchmark/evaluation/results.py
@@ -7,7 +7,11 @@ from scipy.stats import rankdata
 
 def save_results(experiment_name, task_results, output_dir: Path, config: dict = None):
     """Save raw results with timestamp and optional config snapshot."""
-
+    
+    # Cast output_dir to Path
+    if not isinstance(output_dir, Path):
+        output_dir = Path(output_dir)
+        
     result_path = output_dir / "results_summary.json"
 
     metadata = {
@@ -23,6 +27,10 @@ def save_results(experiment_name, task_results, output_dir: Path, config: dict =
 
 def aggregate_results(output_dir: Path, phase: str) -> pd.DataFrame:
     """Aggregate all runs under a given phase into a DataFrame."""
+    # Cast output_dir to Path
+    if not isinstance(output_dir, Path):
+        output_dir = Path(output_dir)
+        
     phase_path = output_dir / phase
     if not phase_path.exists():
         raise FileNotFoundError(f"No results found under {phase_path}")
@@ -81,8 +89,13 @@ def compute_leaderboard(df: pd.DataFrame, metric_columns: list[str]) -> pd.DataF
 
 def save_leaderboard(df: pd.DataFrame, output_dir: Path, phase: str):
     """Save leaderboard summary CSV (including mean_score, weighted_score, aggregated_rank)."""
+    # Cast output_dir to Path
+    if not isinstance(output_dir, Path):
+        output_dir = Path(output_dir)
+    
     leaderboard_path = output_dir / "leaderboards" / phase
     leaderboard_path.mkdir(parents=True, exist_ok=True)
+    
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     out_file = leaderboard_path / f"leaderboard_{timestamp}.csv"
     df.to_csv(out_file, index=False)


### PR DESCRIPTION
This PR contains three parts, one main and two quality of life:
- Introduce an option in the `config.yaml` configuration file to set a flag `output_fold_results` which toggles storing the performance metric per fold for each task as a list. If the flag is set to TRUE, fold performance results are stored in the per-task result files, but not the summary result file.
- Add standard objects to `.gitignore`.
- Add type cast into `pathlib.Path` in `benchmark.evaluation.result.py`. This change allows for using string paths as input.